### PR TITLE
Improved brcmfmac BT coexistence parameters

### DIFF
--- a/brcm/brcmfmac43430-sdio.txt
+++ b/brcm/brcmfmac43430-sdio.txt
@@ -57,3 +57,8 @@ muxenab=0x1
 
 #VCO freq 326.4MHz
 spurconfig=0x3 
+
+# Improved Bluetooth coexistence parameters from Cypress
+btc_mode=1
+btc_params8=0x4e20
+btc_params1=0x7530

--- a/brcm/brcmfmac43455-sdio.txt
+++ b/brcm/brcmfmac43455-sdio.txt
@@ -90,3 +90,8 @@ txpwr5gAdcScale=1
 dot11b_opts=0x3aa85
 cbfilttype=1
 fdsslevel_ch11=6
+
+# Improved Bluetooth coexistence parameters from Cypress
+btc_mode=1
+btc_params8=0x4e20
+btc_params1=0x7530

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+firmware-nonfree (1:20161130-3+rpt4) stretch; urgency=medium
+
+  * Improved brcmfmac BT coexistence parameters
+
+ -- Serge Schneider <serge@raspberrypi.org>  Mon, 20 Aug 2018 10:53:55 +0100
+
 firmware-nonfree (1:20161130-3+rpt3) stretch; urgency=medium
 
   * Add brcmfmac43455-sdio version 7.45.154

--- a/debian/patches/sdio-txt-files.patch
+++ b/debian/patches/sdio-txt-files.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/brcm/brcmfmac43430-sdio.txt
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,64 @@
 +# NVRAM file for BCM943430WLSELG
 +# 2.4 GHz, 20 MHz BW mode
 +
@@ -60,9 +60,14 @@
 +
 +#VCO freq 326.4MHz
 +spurconfig=0x3 
++
++# Improved Bluetooth coexistence parameters from Cypress
++btc_mode=1
++btc_params8=0x4e20
++btc_params1=0x7530
 --- /dev/null
 +++ b/brcm/brcmfmac43455-sdio.txt
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,97 @@
 +# Cloned from bcm94345wlpagb_p2xx.txt 
 +NVRAMRev=$Rev: 498373 $
 +sromrev=11
@@ -155,3 +160,8 @@
 +dot11b_opts=0x3aa85
 +cbfilttype=1
 +fdsslevel_ch11=6
++
++# Improved Bluetooth coexistence parameters from Cypress
++btc_mode=1
++btc_params8=0x4e20
++btc_params1=0x7530

--- a/debian/source/include-binaries
+++ b/debian/source/include-binaries
@@ -22,4 +22,3 @@ debian/config/misc-nonfree/i915/kbl_guc_ver9_14.bin
 brcm/brcmfmac43430-sdio.bin
 brcm/brcmfmac43455-sdio.bin
 brcm/brcmfmac43455-sdio.clm_blob
-brcm/brcmfmac43455-sdio.txt


### PR DESCRIPTION
Cypress have provided some Bluetooth coexistence settings that
greatly improve BT streaming quality when WiFi is active.

See: https://github.com/raspberrypi/linux/issues/1402

Signed-off-by: Phil Elwell <phil@raspberrypi.org>