### PR TITLE
brcmfmac43455-sdio.txt: Sync NVRAM configuration Raspbian

### DIFF
--- a/brcm/brcmfmac43455-sdio.txt
+++ b/brcm/brcmfmac43455-sdio.txt
@@ -21,7 +21,7 @@ btc_mode=1
 #            bit1 for btcoex
 boardflags=0x00480201
 boardflags2=0x40800000
-boardflags3=0x48200100
+boardflags3=0x44200100
 phycal_tempdelta=15
 rxchain=1
 txchain=1


### PR DESCRIPTION
Fixes: https://github.com/RPi-Distro/firmware-nonfree/issues/3

Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>