### PR TITLE
Add Pi 5-specific links to the 43455 firmware

### DIFF
--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin
@@ -1,0 +1,1 @@
+../../cypress/cyfmac43455-sdio.bin

--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.clm_blob
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.clm_blob
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.clm_blob

--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.txt


### PR DESCRIPTION
Silence some kernel warnings by providing model-specific symlinks for the Pi 5 to the 43455 firmware.