### PR TITLE
Add 43455 links for CM5 and Pi500

### DIFF
--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.bin
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.bin
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.bin

--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.clm_blob
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.clm_blob
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.clm_blob

--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.txt
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.txt
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.txt

--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,500.bin
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,500.bin
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.bin

--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,500.clm_blob
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,500.clm_blob
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.clm_blob

--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,500.txt
+++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,500.txt
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.txt


### PR DESCRIPTION
Silence kernel warnings about missing model-specific symlinks for CM5 and Pi 500 to the 43455 firmware.